### PR TITLE
Updates to LOS 16 build process

### DIFF
--- a/0001-Remove-fsck-SELinux-labels.patch
+++ b/0001-Remove-fsck-SELinux-labels.patch
@@ -1,0 +1,29 @@
+From d922de7e988db91e16f0d9c15b5589026e7bc11c Mon Sep 17 00:00:00 2001
+From: Andy CrossGate Yan <GeForce8800Ultra@gmail.com>
+Date: Wed, 23 Oct 2019 09:38:16 +0000
+Subject: [PATCH] Remove fsck SELinux labels
+
+These are covered by LOS sepolicy
+
+Change-Id: I7c63c9aed39afc07b8c80918053154113f848cd9
+---
+ sepolicy/file_contexts | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/sepolicy/file_contexts b/sepolicy/file_contexts
+index 1160738..a29bd32 100644
+--- a/sepolicy/file_contexts
++++ b/sepolicy/file_contexts
+@@ -4,8 +4,5 @@
+ /system/bin/rw-system.sh u:object_r:phhsu_exec:s0
+ /system/bin/phh-on-boot.sh u:object_r:phhsu_exec:s0
+ 
+-/system/bin/fsck\.exfat                 u:object_r:fsck_exec:s0
+-/system/bin/fsck\.ntfs                  u:object_r:fsck_exec:s0
+-
+ /sec_storage(/.*)?      u:object_r:teecd_data_file:s0
+ /dev/dsm                u:object_r:dmd_device:s0
+ 
+-- 
+2.17.1
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-Prerequisite: sync [treble_experimentations](https://github.com/AndyCGYan/treble_experimentations) to `~`; sync [treble_patches](https://github.com/AndyCGYan/treble_patches) to `treble_patches` under workspace root
+## Getting Started ##
+---------------
+
+To get started with building LineageOS GSI, you'll need to get familiar with [Git and Repo](https://source.android.com/source/using-repo.html) as well as [How to build a GSI](https://github.com/phhusson/treble_experimentations/wiki/How-to-build-a-GSI%3F).
+
+First, open a new Terminal window, which defaults to your home directory.  Clone the treble experimentations repo there:
+
+    git clone https://github.com/phhusson/treble_experimentations
+
+Create a new working directory for your LineageOS build and navigate to it:
+
+    mkdir lineage-16.0; cd lineage-16.0
+
+To initialize your local repository of LineageOS, use a command like this:
+
+    repo init -u https://github.com/LineageOS/android.git -b lineage-16.0
+
+Then add repositories for the treble patches and LineageOS build tweaks:
+
+    git clone https://github.com/AndyCGYan/treble_patches -b lineage-16.0
+    git clone https://github.com/Magendanz/treble_build_los -b lineage-16.0
+
+Finally, start the build script:
+
+    bash treble_build_los/build_treble_vanilla.sh

--- a/build_treble_vanilla.sh
+++ b/build_treble_vanilla.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 
-repo sync -c --force-sync --no-clone-bundle --no-tags -j$(nproc --all)
+jobs=$(nproc --all)
+rom_fp="$(date +%Y%m%d)"
+tbl=$PWD/treble_build_los
+
+echo "Preparing local manifest"
+mkdir -p .repo/local_manifests
+cp $tbl/roomservice.xml .repo/local_manifests/manifest.xml
+sed -i -E '/external\/exfat/d' .repo/local_manifests/manifest.xml
+
+repo sync -c --force-sync --no-clone-bundle --no-tags -j$jobs
 
 cd frameworks/base
 git revert e0a5469cf5a2345fae7e81d16d717d285acd3a6e --no-edit #FODCircleView: defer removal to next re-layout
@@ -12,6 +21,8 @@ cd device/phh/treble
 git clean -fdx
 bash generate.sh lineage
 cd ../../..
+
+echo "Applying treble patches"
 bash ~/treble_experimentations/apply-patches.sh treble_patches
 
 echo "Setting up build environment"
@@ -20,41 +31,41 @@ echo ""
 
 echo "Applying universal patches"
 cd frameworks/base
-git am ../../0001-Disable-vendor-mismatch-warning.patch
-git am ../../0001-Keyguard-Show-shortcuts-by-default.patch
-git am ../../0001-core-Add-support-for-MicroG.patch
+git am $tbl/0001-Disable-vendor-mismatch-warning.patch
+git am $tbl/0001-Keyguard-Show-shortcuts-by-default.patch
+git am $tbl/0001-core-Add-support-for-MicroG.patch
 cd ../..
 cd lineage-sdk
-git am ../0001-sdk-Invert-per-app-stretch-to-fullscreen.patch
+git am $tbl/0001-sdk-Invert-per-app-stretch-to-fullscreen.patch
 cd ..
 cd packages/apps/LineageParts
-git am ../../../0001-LineageParts-Invert-per-app-stretch-to-fullscreen.patch
+git am $tbl/0001-LineageParts-Invert-per-app-stretch-to-fullscreen.patch
 cd ../../..
 cd vendor/lineage
-git am ../../0001-vendor_lineage-Log-privapp-permissions-whitelist-vio.patch
+git am $tbl/0001-vendor_lineage-Log-privapp-permissions-whitelist-vio.patch
 cd ../..
 echo ""
 
 echo "Applying GSI-specific patches"
 cd build/make
-git am ../../0001-Revert-Enable-dyanmic-image-size-for-GSI.patch
+git am $tbl/0001-Revert-Enable-dyanmic-image-size-for-GSI.patch
 cd ../..
 cd device/phh/treble
 git revert 82b15278bad816632dcaeaed623b569978e9840d --no-edit #Update lineage.mk for LineageOS 16.0
-git revert df25576594f684ed35610b7cc1db2b72bc1fc4d6 --no-edit #exfat fsck/mkfs selinux label
-git am ../../../0001-treble-Add-overlay-lineage.patch
-git am ../../../0001-treble-Don-t-specify-config_wallpaperCropperPackage.patch
-git am ../../../0001-Increase-system-partition-size-for-arm_ab.patch
+git am $tbl/0001-Remove-fsck-SELinux-labels.patch
+git am $tbl/0001-treble-Add-overlay-lineage.patch
+git am $tbl/0001-treble-Don-t-specify-config_wallpaperCropperPackage.patch
+git am $tbl/0001-Increase-system-partition-size-for-arm_ab.patch
 cd ../../..
 cd external/tinycompress
 git revert fbe2bd5c3d670234c3c92f875986acc148e6d792 --no-edit #tinycompress: Use generated kernel headers
 cd ../..
 cd vendor/lineage
-git am ../../0001-build_soong-Disable-generated_kernel_headers.patch
+git am $tbl/0001-build_soong-Disable-generated_kernel_headers.patch
 cd ../..
 cd vendor/qcom/opensource/cryptfs_hw
 git revert 6a3fc11bcc95d1abebb60e5d714adf75ece83102 --no-edit #cryptfs_hw: Use generated kernel headers
-git am ../../../../0001-Header-hack-to-compile-for-8974.patch
+git am $tbl/0001-Header-hack-to-compile-for-8974.patch
 cd ../../../..
 echo ""
 
@@ -62,11 +73,26 @@ echo "CHECK PATCH STATUS NOW!"
 sleep 5
 echo ""
 
-lunch treble_arm64_avN-userdebug
-make WITHOUT_CHECK_API=true installclean
-make WITHOUT_CHECK_API=true systemimage
-make WITHOUT_CHECK_API=true vndk-test-sepolicy
-BUILD_DATE=`date +%Y%m%d`
-mv $OUT/system.img $OUT/lineage-16.0-$BUILD_DATE-UNOFFICIAL-treble_arm64_avN.img
+export WITHOUT_CHECK_API=true
+export ALLOW_MISSING_DEPENDENCIES=true
+export WITH_SU=true
+export BUILD_NUMBER=$rom_fp
+mkdir -p release/$rom_fp/
+
+buildVariant() {
+	lunch treble_${1}-userdebug
+	make installclean
+	make -j$jobs systemimage
+	make vndk-test-sepolicy
+	mv $OUT/system.img release/$rom_fp/lineage-16.0-$rom_fp-UNOFFICIAL-treble_${1}.img
+}
+
+buildVariant arm_avN
+buildVariant arm_bvN
+buildVariant a64_avN
+buildVariant a64_bvN
+buildVariant arm64_avN
+buildVariant arm64_bvN
+
 cat $OUT/system/build.prop | grep security_patch
 echo ""

--- a/roomservice.xml
+++ b/roomservice.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <project name="phhusson/vendor_hardware_overlay" path="vendor/hardware_overlay" remote="github" revision="pie" />
+  <project name="phhusson/device_phh_treble" path="device/phh/treble" remote="github" revision="android-9.0" />
+  <project name="phhusson/vendor_vndk" path="vendor/vndk" remote="github" revision="master" />
+  <project name="phhusson/vendor_vndk-tests" path="vendor/vndk-tests" remote="github" revision="master" />
+  <project name="phhusson/vendor_interfaces" path="vendor/interfaces" remote="github" revision="pie" />
+  <project name="phhusson/vendor_magisk" path="vendor/magisk" remote="github" revision="master" />
+</manifest>


### PR DESCRIPTION
This removes manual steps from the LOS 16 build process, automates builds of all targets to a /releases directory, and migrates a missing patch from the LOS 17 branch.