### PR TITLE
Fix shebangs to use portable env path

### DIFF
--- a/apply_patches.sh
+++ b/apply_patches.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/build_unified.sh
+++ b/build_unified.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo ""
 echo "LineageOS 22 Unified Build Script"
 echo "Executing in 5 seconds - CTRL-C to exit"

--- a/make_clobber.sh
+++ b/make_clobber.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source build/envsetup.sh
 source vendor/lineage/vars/aosp_target_release

--- a/sign_target_files.sh
+++ b/sign_target_files.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 OUTFILE="$1"
 


### PR DESCRIPTION
Update all bash scripts to use #\!/usr/bin/env bash instead of #\!/bin/bash for better portability across different systems where bash may be installed in different locations.