### PR TITLE
Limit repo sync jobs to 8

### DIFF
--- a/buildbot_unified.sh
+++ b/buildbot_unified.sh
@@ -61,7 +61,7 @@ prep_build() {
     echo ""
 
     echo "Syncing repos"
-    repo sync -c --force-sync --no-clone-bundle --no-tags -j$(nproc --all)
+    repo sync -c --force-sync --no-clone-bundle --no-tags -j8
     echo ""
 
     echo "Setting up build environment"


### PR DESCRIPTION
Change the default thread count to 8 to avoid running into API rate limits on higher-threaded CPUs